### PR TITLE
Get the element's relative position to the boundary when dragging

### DIFF
--- a/projects/ngx-drag-resize/src/lib/drag/drag.directive.ts
+++ b/projects/ngx-drag-resize/src/lib/drag/drag.directive.ts
@@ -262,8 +262,8 @@ export class NgxDragDirective extends BoundaryDirective implements OnInit, OnDes
   private emitDrag(nativeEvent?: Event): void {
     const rect = this.elementRef.nativeElement.getBoundingClientRect();
     const positionBasedOnBoundary = {
-      top: this.basedOnBoundary(rect.top, "top"),
-      left: this.basedOnBoundary(rect.left, "left")
+      top: this.basedOnBoundary(rect.top, 'top'),
+      left: this.basedOnBoundary(rect.left, 'left')
     }
 
     this.ngxDragged.emit({

--- a/projects/ngx-drag-resize/src/lib/drag/drag.directive.ts
+++ b/projects/ngx-drag-resize/src/lib/drag/drag.directive.ts
@@ -261,9 +261,14 @@ export class NgxDragDirective extends BoundaryDirective implements OnInit, OnDes
    */
   private emitDrag(nativeEvent?: Event): void {
     const rect = this.elementRef.nativeElement.getBoundingClientRect();
+    const positionBasedOnBoundary = {
+      top: this.basedOnBoundary(rect.top, "top"),
+      left: this.basedOnBoundary(rect.left, "left")
+    }
 
     this.ngxDragged.emit({
       nativeEvent,
+      positionBasedOnBoundary,
       top: rect.top,
       right: rect.right,
       bottom: rect.bottom,

--- a/projects/ngx-drag-resize/src/lib/drag/drag.ts
+++ b/projects/ngx-drag-resize/src/lib/drag/drag.ts
@@ -2,4 +2,5 @@ import {Boundary} from '../shared/boundary/boundary';
 
 export interface NgxDrag extends Boundary {
   nativeEvent?: Event;
+  positionBasedOnBoundary?: {left: number, top: number}
 }


### PR DESCRIPTION
This change resolves #4 by adding the `positionBasedOnBoundary` object to the ngxDragged event emitter.