### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -7,6 +7,9 @@ on:
     types: [published]
 jobs:
   publish-package:
+    permissions:
+      contents: read
+      packages: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/dmytro-parfenov/ngx-drag-resize/security/code-scanning/8](https://github.com/dmytro-parfenov/ngx-drag-resize/security/code-scanning/8)

To fix the issue, we need to explicitly define the `permissions` block in the workflow. Since the workflow involves publishing a package, it requires `contents: read` to access the repository contents and `packages: write` to publish the package. These permissions should be added at the job level to limit their scope to the `publish-package` job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
