### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,4 +1,6 @@
 name: Deploy to Preview Channel on Pull Request
+permissions:
+  contents: read
 on:
   pull_request_target:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/dmytro-parfenov/ngx-drag-resize/security/code-scanning/7](https://github.com/dmytro-parfenov/ngx-drag-resize/security/code-scanning/7)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the least privileges required. Based on the workflow's steps, it does not appear to need write access to the repository contents or other GitHub resources. Therefore, we will set `contents: read` as the minimal permission. This ensures the workflow has only the necessary permissions to execute its tasks securely.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
