### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -2,6 +2,8 @@
 # https://github.com/firebase/firebase-tools
 
 name: Deploy to Firebase Hosting
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/dmytro-parfenov/ngx-drag-resize/security/code-scanning/6](https://github.com/dmytro-parfenov/ngx-drag-resize/security/code-scanning/6)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the minimum required permissions. Since the workflow involves deploying to Firebase Hosting, it likely only needs `contents: read` to access the repository's files. We will add this block at the root level of the workflow to apply it to all jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
